### PR TITLE
Add local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,51 @@ This project supports a master’s thesis titled:
 ---
 
 ## 🗂️ Project Structure
+- `backend/` - FastAPI server with `server.py` and dependencies.
+- `frontend/` - React app powered by Create React App and TailwindCSS.
+- `scripts/` - Helper scripts like `update-and-start.sh` used in dev containers.
+- `backend_test.py` - Stand‑alone API test suite.
 
+## ⚙️ Installing Dependencies
+
+### Backend
+```bash
+pip install -r backend/requirements.txt
+```
+
+### Frontend
+```bash
+cd frontend
+npm install   # or `yarn install`
+```
+
+## ▶️ Running Locally
+
+Start the API server:
+```bash
+cd backend
+uvicorn server:app --reload --port 8001
+```
+
+Start the React frontend in another terminal:
+```bash
+cd frontend
+npm start
+```
+The site will be available at `http://localhost:3000` and the API at `http://localhost:8001`.
+
+## 🐳 Docker
+
+To build and run the full stack via Docker:
+```bash
+docker build -t hami .
+docker run -p 8080:8080 -p 8001:8001 hami
+```
+Open `http://localhost:8080` to view the app.
+
+## 🧪 Running Tests
+
+`backend_test.py` exercises the API endpoints. Make sure the backend is running and edit the `base_url` variable at the bottom of the file if necessary. Then run:
+```bash
+python backend_test.py
+```


### PR DESCRIPTION
## Summary
- document project directory layout
- add dependency installation steps for backend and frontend
- explain how to run the app locally
- document docker build/run workflow
- add instructions for backend_test.py

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6842986191bc8328829e950dbcb419b9