### PR TITLE
Add repository agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Repository Agent Instructions
+
+This file defines conventions for both main and testing agents working in this repository.
+
+## Running the Backend
+- Install dependencies with `pip install -r requirements.txt`.
+- Launch the API from the `backend` directory:
+  ```bash
+  cd backend
+  uvicorn server:app --reload --host 0.0.0.0 --port 8001
+  ```
+
+## Running the Frontend
+- Install dependencies:
+  ```bash
+  cd frontend
+  yarn install
+  ```
+- Start the development server:
+  ```bash
+  yarn start
+  ```
+
+## Testing
+- Run integration tests after the backend is accessible. Execute from the repository root:
+  ```bash
+  python backend_test.py
+  ```
+- If the backend is not running on `http://localhost:8001`, update `base_url` in `backend_test.py` before running tests.
+
+## Linting and Formatting
+- Format and lint Python code:
+  ```bash
+  black backend
+  flake8 backend
+  mypy backend  # optional type checking
+  ```
+- Lint frontend code:
+  ```bash
+  cd frontend
+  npx eslint src --ext .js,.jsx
+  ```
+
+## Required Actions
+- Run the commands in the **Linting and Formatting** and **Testing** sections before committing changes.
+- Ensure `git status` shows a clean working tree prior to completing a pull request.

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -1,0 +1,57 @@
+# Development Guide
+
+This project contains a FastAPI backend and a React frontend. The following instructions outline how to run each service, execute the backend test suite and apply code quality tools.
+
+## Running the Backend
+
+1. Install Python dependencies (preferably in a virtual environment):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the FastAPI server from the `backend` directory:
+   ```bash
+   cd backend
+   uvicorn server:app --reload --host 0.0.0.0 --port 8001
+   ```
+
+## Running the Frontend
+
+1. Install dependencies using `yarn` (or `npm`):
+   ```bash
+   cd frontend
+   yarn install
+   ```
+2. Start the development server:
+   ```bash
+   yarn start
+   ```
+   The application will be available at [http://localhost:3000](http://localhost:3000).
+
+## Executing `backend_test.py`
+
+The file `backend_test.py` performs integration tests against the running API.
+
+1. Ensure the backend is running locally on `http://localhost:8001` or edit the
+   `base_url` inside `backend_test.py` to point to the correct address.
+2. Run the tests from the repository root:
+   ```bash
+   python backend_test.py
+   ```
+
+## Linting and Formatting
+
+The repository uses standard tools for maintaining code style.
+
+- **Python**: Run [Black](https://black.readthedocs.io/) for formatting and
+  [Flake8](https://flake8.pycqa.org/) for linting. Optional type checking can be
+  performed with `mypy`.
+  ```bash
+  black backend
+  flake8 backend
+  mypy backend
+  ```
+- **JavaScript/React**: ESLint is available via the frontend dev dependencies.
+  ```bash
+  cd frontend
+  npx eslint src --ext .js,.jsx
+  ```


### PR DESCRIPTION
## Summary
- add AGENTS.md to describe repo conventions and required commands

## Testing
- `pip install -r requirements.txt` *(install logs truncated)*
- `python backend_test.py` *(fails: 404 page not found)*
- `black backend`
- `flake8 backend` *(reports E501 line length issues)*
- `mypy backend --ignore-missing-imports` *(interrupted)*
- `npx eslint src --ext .js,.jsx` *(fails: config not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d0be9f8483288cf0d216947f9c8b