### PR TITLE
Use API_BASE_URL for tests

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -31,8 +31,9 @@ This project contains a FastAPI backend and a React frontend. The following inst
 
 The file `backend_test.py` performs integration tests against the running API.
 
-1. Ensure the backend is running locally on `http://localhost:8001` or edit the
-   `base_url` inside `backend_test.py` to point to the correct address.
+1. Ensure the backend is running locally on `http://localhost:8001` or set the
+   `API_BASE_URL` environment variable to point to the correct address. The
+   tests default to `http://localhost:8001` if the variable is not set.
 2. Run the tests from the repository root:
    ```bash
    python backend_test.py

--- a/backend_test.py
+++ b/backend_test.py
@@ -2,6 +2,7 @@ import sys
 import uuid
 from datetime import datetime
 
+import os
 import requests
 
 
@@ -341,7 +342,7 @@ class PersianMentalHealthAPITester:
 
 
 def main():
-    base_url = "https://aae197da-d3d8-4951-8d0c-e6ef8f61190f.preview.emergentagent.com"
+    base_url = os.getenv("API_BASE_URL", "http://localhost:8001")
     tester = PersianMentalHealthAPITester(base_url)
     success = tester.run_all_tests()
     return 0 if success else 1


### PR DESCRIPTION
## Summary
- allow `backend_test.py` to read API base url from `API_BASE_URL`
- document the environment variable in the development guide

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d271daa08328b72c7e531a3321f5