### PR TITLE
Add habit journey endpoint and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ This project supports a master’s thesis titled:
 - Interprets results, trends, and suggests next actions
 
 ### 🧭 Personalized Roadmap
-- *Fabulous-style* habit-building journeys
+- *Fabulous-style* habit-building journeys with beautiful routines and progress tracking
 - Suggestions include:
   - Sleep tracking
   - Mindfulness reminders
   - Daily reflections
+  - Short gratitude practice
 
 ### 💬 Persian Chatbot (v1)
 - Simple rule-based assistant in Farsi

--- a/backend/journeys_utils.py
+++ b/backend/journeys_utils.py
@@ -1,0 +1,39 @@
+"""Utility functions for Fabulous-style habit-building journeys."""
+
+from typing import List, Dict
+
+
+def get_default_journeys() -> List[Dict[str, object]]:
+    """Return a list of default habit-building journeys."""
+    return [
+        {
+            "id": "morning-routine",
+            "name": "Morning Routine Kickstart",
+            "description": "Establish a consistent and energizing morning routine.",
+            "tasks": [
+                "Wake up at the same time each day",
+                "Drink a glass of water",
+                "Do 5 minutes of stretching or light exercise",
+            ],
+        },
+        {
+            "id": "mindfulness-master",
+            "name": "Mindfulness Master",
+            "description": "Build daily mindfulness habits to manage stress.",
+            "tasks": [
+                "Practice 3 minutes of deep breathing",
+                "Record a short gratitude note",
+                "Take a mindful walk or body scan",
+            ],
+        },
+        {
+            "id": "sleep-champion",
+            "name": "Sleep Champion",
+            "description": "Improve sleep hygiene for better rest and recovery.",
+            "tasks": [
+                "Set a consistent bedtime",
+                "Avoid screens 30 minutes before sleep",
+                "Create a relaxing pre-sleep ritual",
+            ],
+        },
+    ]

--- a/backend/server.py
+++ b/backend/server.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
 from .gamification_utils import calculate_level_and_badges, calculate_streak
+from .journeys_utils import get_default_journeys
 
 import bcrypt
 import jwt
@@ -107,6 +108,7 @@ async def award_xp(user_id: str, amount: int):
     if not user:
         return
     xp = user.get("xp", 0) + amount
+
 
 async def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(security),
@@ -453,7 +455,6 @@ async def register_user(user_data: UserRegister):
         "xp": 0,
         "level": 1,
         "badges": [],
-
     }
 
     await db.users.insert_one(user_doc)
@@ -470,7 +471,6 @@ async def register_user(user_data: UserRegister):
         "xp": 0,
         "level": 1,
         "badges": [],
-
     }
 
     return {"access_token": access_token, "token_type": "bearer", "user": user_response}
@@ -500,8 +500,6 @@ async def login_user(user_data: UserLogin):
         "xp": user.get("xp", 0),
         "level": user.get("level", 1),
         "badges": user.get("badges", []),
-
-
     }
 
     return {"access_token": access_token, "token_type": "bearer", "user": user_response}
@@ -518,7 +516,6 @@ async def get_profile(current_user=Depends(get_current_user)):
         "xp": current_user.get("xp", 0),
         "level": current_user.get("level", 1),
         "badges": current_user.get("badges", []),
-
     }
 
 
@@ -613,8 +610,6 @@ async def save_mood_entry(mood_data: MoodEntry, current_user=Depends(get_current
         mood_doc["entry_id"] = str(uuid.uuid4())
         await db.mood_entries.insert_one(mood_doc)
 
-
-
     return {"message": "خلق و خو با موفقیت ذخیره شد"}
 
 
@@ -669,6 +664,12 @@ async def get_mental_health_plan(current_user=Depends(get_current_user)):
     return plan
 
 
+@app.get("/api/journeys")
+async def get_journeys(_: Any = Depends(get_current_user)):
+    """Return available habit-building journeys."""
+    return get_default_journeys()
+
+
 @app.get("/api/assessments")
 async def get_user_assessments(current_user=Depends(get_current_user)):
     assessments = (
@@ -687,7 +688,6 @@ async def get_gamification(current_user=Depends(get_current_user)):
         "xp": user.get("xp", 0),
         "level": user.get("level", 1),
         "badges": user.get("badges", []),
-
     }
 
 

--- a/tests/test_journeys.py
+++ b/tests/test_journeys.py
@@ -1,0 +1,11 @@
+from backend.journeys_utils import get_default_journeys
+
+
+def test_journeys_structure():
+    journeys = get_default_journeys()
+    assert len(journeys) >= 3
+    for j in journeys:
+        assert "id" in j
+        assert "name" in j
+        assert "description" in j
+        assert isinstance(j.get("tasks"), list)


### PR DESCRIPTION
## Summary
- create `journeys_utils.py` with default Fabulous-style journeys
- expose new `/api/journeys` endpoint
- add unit test for journeys
- enhance README about personalized roadmap

## Testing
- `black backend tests`
- `flake8 backend` *(fails: E501 and other issues)*
- `mypy backend` *(fails: missing stubs and typing errors)*
- `npx eslint src --ext .js,.jsx` *(fails: config missing)*
- `python backend_test.py` *(fails: connection refused)*
- `pytest -q tests/test_journeys.py`

------
https://chatgpt.com/codex/tasks/task_e_6842dd11a7ac83288da372a7988e50df