### PR TITLE
Add sleep tracking and reflections

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This project supports a master’s thesis titled:
 - “How are you feeling today?” prompt
 - Emoji/scale-based logging + optional journaling
 - Used for AI pattern detection & roadmap planning
+- Sleep tracking for hours and quality
+- Daily reflections journal
 
 ### 🤖 AI Analysis
 - **NLP** on text input (journal/chat) using HuggingFace (e.g., ParsBERT)

--- a/backend_test.py
+++ b/backend_test.py
@@ -191,6 +191,53 @@ class PersianMentalHealthAPITester:
             print("✅ Mood entries retrieval successful")
         return success
 
+    def test_sleep_entry(self):
+        """Test saving sleep entry"""
+        sleep_data = {"hours": 7.5, "quality": 4, "note": "Good sleep"}
+        success, data = self.run_test(
+            "Save Sleep Entry", "POST", "api/sleep-entry", 200, data=sleep_data
+        )
+        if success:
+            assert "message" in data
+            print("✅ Sleep entry saved successfully")
+        return success
+
+    def test_get_sleep_entries(self):
+        """Test getting sleep entries"""
+        success, data = self.run_test(
+            "Get Sleep Entries", "GET", "api/sleep-entries", 200
+        )
+        if success:
+            assert isinstance(data, list)
+            if len(data) > 0:
+                assert "hours" in data[0]
+                assert "quality" in data[0]
+            print("✅ Sleep entries retrieval successful")
+        return success
+
+    def test_daily_reflection(self):
+        """Test saving daily reflection"""
+        ref = {"text": "Feeling productive"}
+        success, data = self.run_test(
+            "Save Daily Reflection", "POST", "api/daily-reflection", 200, data=ref
+        )
+        if success:
+            assert "message" in data
+            print("✅ Daily reflection saved successfully")
+        return success
+
+    def test_get_daily_reflections(self):
+        """Test getting reflections"""
+        success, data = self.run_test(
+            "Get Daily Reflections", "GET", "api/daily-reflections", 200
+        )
+        if success:
+            assert isinstance(data, list)
+            if len(data) > 0:
+                assert "text" in data[0]
+            print("✅ Daily reflections retrieval successful")
+        return success
+
     def test_chat_with_bot(self):
         """Test chatting with the bot"""
         # Test different types of messages
@@ -325,6 +372,10 @@ class PersianMentalHealthAPITester:
             self.test_submit_phq9()
             self.test_mood_entry()
             self.test_get_mood_entries()
+            self.test_sleep_entry()
+            self.test_get_sleep_entries()
+            self.test_daily_reflection()
+            self.test_get_daily_reflections()
             self.test_chat_with_bot()
             self.test_get_mental_health_plan()
             self.test_get_assessments()

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -37,6 +37,14 @@ const Dashboard = ({ handleLogout, user, gamification, todayMood, getMoodText, s
         <h3 className="text-xl font-bold text-right mb-2">ثبت خلق و خو روزانه</h3>
         <p className="text-right opacity-90">امروز چطور احساس می‌کنید؟</p>
       </div>
+      <div onClick={() => setCurrentPage('sleep-tracker')} className="bg-gradient-to-br from-teal-500 to-blue-600 text-white p-6 rounded-lg cursor-pointer hover:shadow-lg transition-shadow">
+        <h3 className="text-xl font-bold text-right mb-2">پیگیری خواب</h3>
+        <p className="text-right opacity-90">ثبت مدت و کیفیت خواب</p>
+      </div>
+      <div onClick={() => setCurrentPage('daily-reflection')} className="bg-gradient-to-br from-yellow-500 to-orange-600 text-white p-6 rounded-lg cursor-pointer hover:shadow-lg transition-shadow">
+        <h3 className="text-xl font-bold text-right mb-2">یادداشت روزانه</h3>
+        <p className="text-right opacity-90">نوشتن افکار و احساسات</p>
+      </div>
       <div onClick={() => setCurrentPage('chatbot')} className="bg-gradient-to-br from-orange-500 to-red-600 text-white p-6 rounded-lg cursor-pointer hover:shadow-lg transition-shadow">
         <h3 className="text-xl font-bold text-right mb-2">گپ با مشاور</h3>
         <p className="text-right opacity-90">صحبت کردن می‌تواند کمک کند</p>


### PR DESCRIPTION
## Summary
- support sleep entries and daily reflections on the FastAPI server
- enable saving and retrieving sleep/reflection data in backend tests
- include sleep & reflection pages in the React app
- display new options in the dashboard
- document sleep tracking and daily reflections in README

## Testing
- `pip install -r requirements.txt`
- `yarn install` *(fails: The lockfile would have been modified)*
- `black backend`
- `flake8 backend` *(fails: E501 and F401 issues)*
- `mypy backend` *(fails with missing stubs)*
- `npx eslint src --ext .js,.jsx` *(fails: ESLint couldn't find config file)*
- `python backend_test.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6842dd961e5083289997a86a82a14595