### PR TITLE
Mark dashboard retest

### DIFF
--- a/test_result.md
+++ b/test_result.md
@@ -132,7 +132,7 @@ frontend:
     file: "frontend/src/components/Dashboard.js"
     stuck_count: 0
     priority: "high"
-    needs_retesting: false
+    needs_retesting: true
     status_history:
       - working: true
         agent: "main"
@@ -158,3 +158,5 @@ test_plan:
 agent_communication:
   - agent: "main"
     message: "Added chart features and ran tests."
+  - agent: "main"
+    message: "Attempted dashboard retest; environment missing dependencies prevented full execution."


### PR DESCRIPTION
## Summary
- mark dashboard charts for retesting
- note testing attempt

## Testing
- `black backend`
- `flake8 backend` *(fails: E501 line too long etc.)*
- `mypy backend` *(fails: missing stubs etc.)*
- `pip install -r backend/requirements.txt` *(fails: large downloads, interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_6842dc448a8883288cbd2adc2921d5a9