### PR TITLE
Update port mapping for nginx in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   app:
     build: .
     ports:
-      - "3000:80"
+      - "3000:8080"
       - "8001:8001"
     environment:
       - FRONTEND_ENV=


### PR DESCRIPTION
## Summary
- map host port 3000 to container port 8080

## Testing
- `black backend`
- `flake8 backend`
- `mypy backend` *(fails: Cannot find implementation or library stub for module named "transformers")*
- `npx eslint src --ext .js,.jsx` *(fails: ESLint couldn't find a config file)*
- `python backend_test.py` *(fails: connection refused)*
- `docker-compose up --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870e01a1530832893d3c0456df63eda