### PR TITLE
Update black requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ tenacity==8.2.3
 python-json-logger==2.0.7
 pytest==8.0.0
 pytest-cov==4.1.0
-black==24.1.1
+black>=24.3.0
 flake8==7.0.0
 mypy==1.8.0
 pyyaml>=6.0.2


### PR DESCRIPTION
## Summary
- bump `black` to `>=24.3.0` in `requirements.txt`

## Testing
- `pip-audit -r requirements.txt`
- `black backend -q`
- `flake8 backend`
- `mypy backend` *(fails: Cannot find implementation or library stub for module named 'transformers')*
- `npx eslint src --ext .js,.jsx` *(fails: ESLint couldn't find an eslint.config file)*
- `python backend_test.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6870e01ea3f48328b903f4eb8525283e