### PR TITLE
Add Farsi validation messages

### DIFF
--- a/frontend/src/components/AuthForm.js
+++ b/frontend/src/components/AuthForm.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+const REQUIRED_MESSAGE = 'لطفاً این فیلد را پر کنید';
+
 const AuthForm = ({ authMode, setAuthMode, authData, setAuthData, handleAuth, loading, error }) => (
   <div className="bg-white rounded-lg p-8 shadow-lg max-w-md mx-auto">
     <h2 className="text-2xl font-bold text-right text-gray-800 mb-6">
@@ -15,6 +17,8 @@ const AuthForm = ({ authMode, setAuthMode, authData, setAuthData, handleAuth, lo
             onChange={e => setAuthData({ ...authData, fullName: e.target.value })}
             className="w-full p-3 border rounded-lg text-right"
             required
+            onInvalid={e => e.target.setCustomValidity(REQUIRED_MESSAGE)}
+            onInput={e => e.target.setCustomValidity('')}
           />
           <input
             type="number"
@@ -23,12 +27,16 @@ const AuthForm = ({ authMode, setAuthMode, authData, setAuthData, handleAuth, lo
             onChange={e => setAuthData({ ...authData, age: e.target.value })}
             className="w-full p-3 border rounded-lg text-right"
             required
+            onInvalid={e => e.target.setCustomValidity(REQUIRED_MESSAGE)}
+            onInput={e => e.target.setCustomValidity('')}
           />
           <select
             value={authData.studentLevel}
             onChange={e => setAuthData({ ...authData, studentLevel: e.target.value })}
             className="w-full p-3 border rounded-lg text-right cursor-pointer"
             required
+            onInvalid={e => e.target.setCustomValidity(REQUIRED_MESSAGE)}
+            onInput={e => e.target.setCustomValidity('')}
           >
             <option value="" disabled>سطح تحصیلات</option>
             <option value="undergraduate">کارشناسی</option>
@@ -37,22 +45,26 @@ const AuthForm = ({ authMode, setAuthMode, authData, setAuthData, handleAuth, lo
           </select>
         </>
       )}
-      <input
-        type="email"
-        placeholder="ایمیل"
-        value={authData.email}
-        onChange={e => setAuthData({ ...authData, email: e.target.value })}
-        className="w-full p-3 border rounded-lg text-right"
-        required
-      />
-      <input
-        type="password"
-        placeholder="رمز عبور"
-        value={authData.password}
-        onChange={e => setAuthData({ ...authData, password: e.target.value })}
-        className="w-full p-3 border rounded-lg text-right"
-        required
-      />
+        <input
+          type="email"
+          placeholder="ایمیل"
+          value={authData.email}
+          onChange={e => setAuthData({ ...authData, email: e.target.value })}
+          className="w-full p-3 border rounded-lg text-right"
+          required
+          onInvalid={e => e.target.setCustomValidity(REQUIRED_MESSAGE)}
+          onInput={e => e.target.setCustomValidity('')}
+        />
+        <input
+          type="password"
+          placeholder="رمز عبور"
+          value={authData.password}
+          onChange={e => setAuthData({ ...authData, password: e.target.value })}
+          className="w-full p-3 border rounded-lg text-right"
+          required
+          onInvalid={e => e.target.setCustomValidity(REQUIRED_MESSAGE)}
+          onInput={e => e.target.setCustomValidity('')}
+        />
       {authMode === 'register' && (
         <input
           type="password"
@@ -61,6 +73,8 @@ const AuthForm = ({ authMode, setAuthMode, authData, setAuthData, handleAuth, lo
           onChange={e => setAuthData({ ...authData, confirmPassword: e.target.value })}
           className="w-full p-3 border rounded-lg text-right"
           required
+          onInvalid={e => e.target.setCustomValidity(REQUIRED_MESSAGE)}
+          onInput={e => e.target.setCustomValidity('')}
         />
       )}
       {error && <p className="text-red-500 text-right">{error}</p>}


### PR DESCRIPTION
## Summary
- customize HTML5 validation messages in the auth form

## Testing
- `npx eslint src --ext .js,.jsx` *(fails: ESLint couldn't find a config)*
- `black backend`
- `flake8 backend`
- `mypy backend` *(fails: process interrupted)*
- `python backend_test.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6871138fd7988328b1f84f57a89885ca