### PR TITLE
Fix age validation and backend defaults

### DIFF
--- a/backend/nlp_analysis.py
+++ b/backend/nlp_analysis.py
@@ -8,7 +8,9 @@ from transformers import pipeline
 @lru_cache(maxsize=1)
 def get_sentiment_pipeline():
     """Load a sentiment-analysis pipeline for Persian text."""
-    model_name = os.getenv("SENTIMENT_MODEL", "HooshvareLab/bert-base-parsbert-uncased-sentiment")
+    model_name = os.getenv(
+        "SENTIMENT_MODEL", "HooshvareLab/bert-base-parsbert-uncased-sentiment"
+    )
     return pipeline("sentiment-analysis", model=model_name)
 
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -59,7 +59,8 @@ const App = () => {
 
 
 
-  const backendUrl = process.env.REACT_APP_BACKEND_URL;
+  const backendUrl =
+    process.env.REACT_APP_BACKEND_URL || 'http://localhost:8001';
 
   useEffect(() => {
     const token = localStorage.getItem('token');
@@ -152,9 +153,18 @@ const App = () => {
 
     try {
       const endpoint = authMode === 'login' ? '/api/login' : '/api/register';
-      const payload = authMode === 'login' 
-        ? { email: authData.email, password: authData.password }
-        : authData;
+      let payload;
+      if (authMode === 'login') {
+        payload = { email: authData.email, password: authData.password };
+      } else {
+        const ageNum = Number(authData.age);
+        if (!ageNum || ageNum < 10 || ageNum > 100) {
+          setError('سن باید بین 10 و 100 باشد');
+          setLoading(false);
+          return;
+        }
+        payload = { ...authData, age: ageNum };
+      }
 
       const response = await axios.post(`${backendUrl}${endpoint}`, payload);
 
@@ -946,11 +956,39 @@ const ConsentForm = () => (
         {currentPage === 'auth' && (
           <div className="space-y-8">
             {authMode === 'register' && <ConsentForm />}
-            <AuthForm />
+            <AuthForm
+              authMode={authMode}
+              setAuthMode={setAuthMode}
+              authData={authData}
+              setAuthData={setAuthData}
+              handleAuth={handleAuth}
+              loading={loading}
+              error={error}
+            />
           </div>
         )}
-        {currentPage === 'dashboard' && <Dashboard />}
-        {currentPage === 'dass21' && <DASS21Test />}
+        {currentPage === 'dashboard' && (
+          <Dashboard
+            handleLogout={handleLogout}
+            user={user}
+            gamification={gamification}
+            todayMood={todayMood}
+            getMoodText={getMoodText}
+            setCurrentPage={setCurrentPage}
+            moodHistory={moodHistory}
+            assessmentHistory={assessmentHistory}
+          />
+        )}
+        {currentPage === 'dass21' && (
+          <DASS21Test
+            setCurrentPage={setCurrentPage}
+            dass21Questions={dass21Questions}
+            dassResponses={dassResponses}
+            setDassResponses={setDassResponses}
+            submitDASS21={submitDASS21}
+            loading={loading}
+          />
+        )}
         {currentPage === 'phq9' && <PHQ9Test />}
         {currentPage === 'mood-tracker' && <MoodTracker />}
         {currentPage === 'sleep-tracker' && <SleepTracker />}

--- a/frontend/src/components/AuthForm.js
+++ b/frontend/src/components/AuthForm.js
@@ -20,6 +20,8 @@ const AuthForm = ({ authMode, setAuthMode, authData, setAuthData, handleAuth, lo
             type="number"
             placeholder="سن"
             value={authData.age}
+            min="10"
+            max="100"
             onChange={e => setAuthData({ ...authData, age: e.target.value })}
             className="w-full p-3 border rounded-lg text-right"
             required


### PR DESCRIPTION
## Summary
- enforce reasonable age limits on signup
- default backendUrl to localhost when env var missing

## Testing
- `black backend`
- `flake8 backend`
- `mypy backend` *(fails: INTERNAL ERROR)*
- `cd frontend && npx eslint src --ext .js,.jsx` *(fails: ESLint couldn't find a config file)*
- `python backend_test.py` *(fails: several tests due to server errors)*

------
https://chatgpt.com/codex/tasks/task_e_6870ec3898d88328b3e7178fe290cbff