### PR TITLE
Add admin creation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,13 @@ Unit tests can still be executed directly with:
 ```bash
 pytest --cov=backend tests
 ```
+
+### Create Admin User (Optional)
+
+For local testing you may want a predefined admin account. Run the helper script:
+
+```bash
+python scripts/create_admin_user.py
+```
+
+You can override the defaults using `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables.

--- a/scripts/create_admin_user.py
+++ b/scripts/create_admin_user.py
@@ -1,0 +1,40 @@
+import asyncio
+import os
+import uuid
+from datetime import datetime
+
+from database import db
+from auth import hash_password
+
+DEFAULT_EMAIL = os.getenv("ADMIN_EMAIL", "admin@example.com")
+DEFAULT_PASSWORD = os.getenv("ADMIN_PASSWORD", "123456")
+
+
+async def main():
+    existing = await db.users.find_one({"email": DEFAULT_EMAIL})
+    if existing:
+        print(f"User already exists: {DEFAULT_EMAIL}")
+        return
+
+    user_doc = {
+        "user_id": str(uuid.uuid4()),
+        "email": DEFAULT_EMAIL,
+        "password": hash_password(DEFAULT_PASSWORD),
+        "full_name": "Admin User",
+        "age": 30,
+        "student_level": "admin",
+        "consent_given": True,
+        "created_at": datetime.utcnow(),
+        "last_login": datetime.utcnow(),
+        "xp": 0,
+        "level": 1,
+        "memory": {},
+        "badges": [],
+        "is_admin": True,
+    }
+    await db.users.insert_one(user_doc)
+    print(f"Admin user created: {DEFAULT_EMAIL}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- script to insert a local admin account
- document how to run the helper script

## Testing
- `black backend scripts/create_admin_user.py`
- `flake8 backend scripts/create_admin_user.py`
- `mypy backend scripts/create_admin_user.py` *(fails: No module named 'transformers')*
- `npx eslint src --ext .js,.jsx` *(fails: ESLint couldn't find config)*
- `python backend_test.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687116cbf154832890cee6bdf86158e7