### PR TITLE
Add ESLint configuration

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,22 @@
+import js from '@eslint/js';
+import react from 'eslint-plugin-react';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
+import importPlugin from 'eslint-plugin-import';
+import globals from 'globals';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.{js,jsx}'],
+    languageOptions: {
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module', ecmaFeatures: { jsx: true } },
+      globals: { ...globals.browser, ...globals.node },
+    },
+    plugins: { react, 'jsx-a11y': jsxA11y, import: importPlugin },
+    settings: { react: { version: 'detect' } },
+    rules: {
+      'react/react-in-jsx-scope': 'off',
+      'no-unused-vars': 'warn',
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- add ESLint configuration for frontend

## Testing
- `black backend`
- `flake8 backend`
- `mypy backend` *(fails: No library stubs for transformers, motor.motor_asyncio)*
- `cd frontend && npx eslint src --ext .js,.jsx`
- `python backend_test.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68711e423a7083289280f45e03452f32