### PR TITLE
Add ESLint config and doc update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ This file defines conventions for both main and testing agents working in this r
 - If the backend is not running on `http://localhost:8001`, update `base_url` in `backend_test.py` before running tests.
 
 ## Linting and Formatting
+- The repository uses an ESLint configuration file. Keep `eslint.config.js` in
+  the repository root to ensure consistent linting.
 - Format and lint Python code:
   ```bash
   black backend
@@ -38,6 +40,7 @@ This file defines conventions for both main and testing agents working in this r
 - Lint frontend code:
   ```bash
   cd frontend
+  # ESLint reads configuration from the root `eslint.config.js`
   npx eslint src --ext .js,.jsx
   ```
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,26 @@
+import js from '@eslint/js';
+import reactPlugin from 'eslint-plugin-react';
+import jsxA11yPlugin from 'eslint-plugin-jsx-a11y';
+import importPlugin from 'eslint-plugin-import';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    plugins: {
+      react: reactPlugin,
+      'jsx-a11y': jsxA11yPlugin,
+      import: importPlugin
+    },
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module'
+    },
+    settings: {
+      react: { version: 'detect' }
+    },
+    rules: {
+      'react/react-in-jsx-scope': 'off'
+    }
+  }
+];


### PR DESCRIPTION
## Summary
- clarify that ESLint configuration is required in `AGENTS.md`
- add `eslint.config.js` and note that ESLint reads from this file

## Testing
- `black backend`
- `flake8 backend`
- `mypy backend` *(fails: cannot find transformers, motor.motor_asyncio)*
- `npx eslint src --ext .js,.jsx` *(fails: cannot find package '@eslint/js')*
- `python backend_test.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6871203c1ac0832880e503d50c3d1c06