### PR TITLE
Require SECRET_KEY for auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,5 @@ SUPABASE_KEY=
 FRONTEND_URL=
 BACKEND_DOCKER_URL=http://host.docker.internal:8009
 MOCK_AUTH=true
-SECRET_KEY=changeme
+# Required for JWT signing
+SECRET_KEY=

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ This project supports a master’s thesis titled:
 - Python 3.11+
 - Node.js 20+
 
+### Environment Variables
+
+Copy `.env.example` to `.env` and set a strong `SECRET_KEY`. The backend will
+raise an error if this variable is missing.
+
 ### Backend
 
 ```bash

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -14,7 +14,9 @@ from gamification_utils import calculate_level_and_badges
 
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
-SECRET_KEY = os.getenv("SECRET_KEY", "changeme")
+SECRET_KEY = os.getenv("SECRET_KEY")
+if not SECRET_KEY:
+    raise RuntimeError("SECRET_KEY environment variable is required")
 
 security = HTTPBearer()
 


### PR DESCRIPTION
## Summary
- enforce required `SECRET_KEY` environment variable
- document `SECRET_KEY` in README
- update `.env.example`

## Testing
- `black backend`
- `flake8 backend`
- `mypy backend` *(fails: missing stubs and imports)*
- `npx eslint src --ext .js,.jsx` *(fails: missing config)*
- `python backend_test.py` *(fails: backend returns errors without MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_6871203bc66c8328956c6c4f2324ec1e