### PR TITLE
Fix ESLint config in frontend

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,45 +1,12 @@
 import js from '@eslint/js';
- 
-import globals from 'globals';
-import reactPlugin from 'eslint-plugin-react';
-import jsxA11yPlugin from 'eslint-plugin-jsx-a11y';
-import importPlugin from 'eslint-plugin-import';
-=======
 import react from 'eslint-plugin-react';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
 import importPlugin from 'eslint-plugin-import';
 import globals from 'globals';
- 
 
 export default [
   js.configs.recommended,
   {
- 
-    languageOptions: {
-      parserOptions: {
-        ecmaVersion: 'latest',
-        sourceType: 'module',
-        ecmaFeatures: { jsx: true },
-      },
-      globals: {
-        ...globals.browser,
-        ...globals.node,
-      },
-    },
-    plugins: {
-      react: reactPlugin,
-      'jsx-a11y': jsxA11yPlugin,
-      import: importPlugin,
-    },
-    settings: {
-      react: { version: 'detect' },
-    },
-    rules: {
-      'react/react-in-jsx-scope': 'off',
-      'react/jsx-uses-react': 'off',
-      'react/jsx-uses-vars': 'error',
-      'no-unused-vars': 'off',
- 
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       parserOptions: { ecmaVersion: 2020, sourceType: 'module', ecmaFeatures: { jsx: true } },
@@ -50,7 +17,6 @@ export default [
     rules: {
       'react/react-in-jsx-scope': 'off',
       'no-unused-vars': 'warn',
- 
     },
   },
 ];


### PR DESCRIPTION
## Summary
- resolve merge conflict markers in `frontend/eslint.config.js`

## Testing
- `black backend`
- `flake8 backend`
- `mypy backend` *(fails: INTERNAL ERROR)*
- `yarn install` in frontend
- `npx eslint src --ext .js,.jsx`
- `SECRET_KEY=dummykey scripts/run_backend_tests.sh` *(fails: 3/7 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_688268320ca4832890be455602e8616e