### PR TITLE
Add missing service scaffolding and gateway config

### DIFF
--- a/backend/gamification.py
+++ b/backend/gamification.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from typing import List
+
+from auth import award_xp, get_current_user
+from database import db
+
+
+router = APIRouter()
+
+
+class AwardRequest(BaseModel):
+    xp: int = 0
+
+
+@router.post("/api/gamification/award")
+async def award_endpoint(request: AwardRequest, current_user=Depends(get_current_user)):
+    return await award_xp(current_user["user_id"], request.xp)
+
+
+@router.get("/api/gamification")
+async def get_gamification(current_user=Depends(get_current_user)):
+    user = await db.users.find_one({"user_id": current_user["user_id"]})
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return {
+        "xp": user.get("xp", 0),
+        "level": user.get("level", 1),
+        "badges": user.get("badges", []),
+    }
+
+
+@router.get("/api/gamification/leaderboard")
+async def leaderboard() -> List[dict]:
+    users = (
+        await db.users.find({}, {"_id": 0, "user_id": 1, "xp": 1})
+        .sort("xp", -1)
+        .limit(10)
+        .to_list(length=10)
+    )
+    return users
+
+
+@router.get("/api/gamification/badges")
+async def badges_catalog() -> List[str]:
+    return ["Novice", "Expert"]

--- a/backend/journeys.py
+++ b/backend/journeys.py
@@ -1,0 +1,48 @@
+from fastapi import APIRouter, Depends, HTTPException
+from typing import List, Dict
+
+from auth import get_current_user
+from database import db
+from journeys_utils import get_default_journeys
+
+
+router = APIRouter()
+
+
+@router.get("/api/journeys")
+async def list_journeys() -> List[Dict[str, object]]:
+    return get_default_journeys()
+
+
+@router.get("/api/journeys/{journey_id}")
+async def get_journey(journey_id: str) -> Dict[str, object]:
+    for journey in get_default_journeys():
+        if journey["id"] == journey_id:
+            return journey
+    raise HTTPException(status_code=404, detail="Journey not found")
+
+
+@router.post("/api/journeys/{journey_id}/start")
+async def start_journey(journey_id: str, current_user=Depends(get_current_user)):
+    progress = {
+        "user_id": current_user["user_id"],
+        "journey_id": journey_id,
+        "current_step": 0,
+    }
+    await db.journey_progress.update_one(
+        {"user_id": current_user["user_id"], "journey_id": journey_id},
+        {"$set": progress},
+        upsert=True,
+    )
+    return progress
+
+
+@router.get("/api/journeys/{journey_id}/progress")
+async def get_progress(journey_id: str, current_user=Depends(get_current_user)):
+    progress = await db.journey_progress.find_one(
+        {"user_id": current_user["user_id"], "journey_id": journey_id},
+        {"_id": 0},
+    )
+    if not progress:
+        raise HTTPException(status_code=404, detail="Journey not started")
+    return progress

--- a/backend/nlp.py
+++ b/backend/nlp.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from nlp_analysis import analyze_mental_state
+
+
+router = APIRouter()
+
+
+class TextRequest(BaseModel):
+    text: str
+
+
+@router.post("/api/nlp/analyze")
+async def analyze(request: TextRequest):
+    return analyze_mental_state(request.text)
+
+
+@router.get("/api/nlp/models")
+async def models():
+    return {"models": ["sentiment-analysis"]}

--- a/backend/services/gamification_service.py
+++ b/backend/services/gamification_service.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from gamification import router as gamification_router
+
+app = FastAPI(title="Gamification Service")
+
+
+@app.get("/api/health")
+async def health_check():
+    return {"status": "healthy"}
+
+
+app.include_router(gamification_router)
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8004)

--- a/backend/services/journeys_service.py
+++ b/backend/services/journeys_service.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from journeys import router as journeys_router
+
+app = FastAPI(title="Journeys Service")
+
+
+@app.get("/api/health")
+async def health_check():
+    return {"status": "healthy"}
+
+
+app.include_router(journeys_router)
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8005)

--- a/backend/services/nlp_service.py
+++ b/backend/services/nlp_service.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from nlp import router as nlp_router
+
+app = FastAPI(title="NLP Service")
+
+
+@app.get("/api/health")
+async def health_check():
+    return {"status": "healthy"}
+
+
+app.include_router(nlp_router)
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8006)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,34 @@ services:
     command: uvicorn services.trackers_service:app --host 0.0.0.0 --port 8003
     ports:
       - "8003:8003"
+  gamification-service:
+    build: .
+    working_dir: /backend
+    command: uvicorn services.gamification_service:app --host 0.0.0.0 --port 8004
+    ports:
+      - "8004:8004"
+  journeys-service:
+    build: .
+    working_dir: /backend
+    command: uvicorn services.journeys_service:app --host 0.0.0.0 --port 8005
+    ports:
+      - "8005:8005"
+  nlp-service:
+    build: .
+    working_dir: /backend
+    command: uvicorn services.nlp_service:app --host 0.0.0.0 --port 8006
+    ports:
+      - "8006:8006"
+  api-gateway:
+    image: nginx:alpine
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - auth-service
+      - assessments-service
+      - trackers-service
+      - gamification-service
+      - journeys-service
+      - nlp-service

--- a/nginx.conf
+++ b/nginx.conf
@@ -7,11 +7,63 @@ http {
   default_type  application/octet-stream;
   sendfile        on;
 
+  upstream auth_service { server auth-service:8001; }
+  upstream assessments_service { server assessments-service:8002; }
+  upstream trackers_service { server trackers-service:8003; }
+  upstream gamification_service { server gamification-service:8004; }
+  upstream journeys_service { server journeys-service:8005; }
+  upstream nlp_service { server nlp-service:8006; }
+
   server {
     listen 8080;
 
-    location /api {
-      proxy_pass http://127.0.0.1:8001;
+    location /api/auth/ {
+      proxy_pass http://auth_service/api/;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection keep-alive;
+      proxy_set_header Host $host;
+      proxy_cache_bypass $http_upgrade;
+    }
+
+    location /api/assessments/ {
+      proxy_pass http://assessments_service/api/;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection keep-alive;
+      proxy_set_header Host $host;
+      proxy_cache_bypass $http_upgrade;
+    }
+
+    location /api/trackers/ {
+      proxy_pass http://trackers_service/api/;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection keep-alive;
+      proxy_set_header Host $host;
+      proxy_cache_bypass $http_upgrade;
+    }
+
+    location /api/gamification/ {
+      proxy_pass http://gamification_service/api/;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection keep-alive;
+      proxy_set_header Host $host;
+      proxy_cache_bypass $http_upgrade;
+    }
+
+    location /api/journeys/ {
+      proxy_pass http://journeys_service/api/;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection keep-alive;
+      proxy_set_header Host $host;
+      proxy_cache_bypass $http_upgrade;
+    }
+
+    location /api/nlp/ {
+      proxy_pass http://nlp_service/api/;
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection keep-alive;


### PR DESCRIPTION
## Summary
- implement gamification, journeys, and NLP API routers
- add FastAPI service entrypoints for new features
- expand docker-compose and nginx gateway configuration

## Testing
- `black backend`
- `flake8 backend` *(no output)*
- `mypy backend` *(fails: INTERNAL ERROR -- Please try using mypy master on GitHub: https://mypy.readthedocs.io/en/stable/common_issues.html#using-a-development-mypy-build)*
- `npx eslint src --ext .js,.jsx` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*
- `python backend_test.py` *(fails: Tests passed: 3/7)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eeee27648328b565616b42f37436