### PR TITLE
Add Kubernetes deployment manifests and Swagger test

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,26 @@ Run all services together:
 docker-compose up --build
 ```
 
+### Kubernetes Deployment
+
+Sample manifests are provided in `k8s/microservices.yaml` for running the
+backend microservices on a Kubernetes cluster.
+
+Build and push the backend image:
+
+```bash
+docker build -t mental-ai-backend .
+```
+
+Apply the resources:
+
+```bash
+kubectl apply -f k8s/microservices.yaml
+```
+
+Each service exposes its own Swagger UI at `/docs` and the OpenAPI schema at
+`/openapi.json`.
+
 ### Running Tests
 
 Start the required FastAPI service in one terminal:

--- a/backend_test.py
+++ b/backend_test.py
@@ -75,6 +75,14 @@ class PersianMentalHealthAPITester:
             print("✅ Health check endpoint is working")
         return success
 
+    def test_openapi_schema(self):
+        """Ensure the OpenAPI schema is exposed for Swagger"""
+        success, data = self.run_test("OpenAPI Schema", "GET", "openapi.json", 200)
+        if success:
+            assert "openapi" in data
+            print("✅ Swagger/OpenAPI documentation available")
+        return success
+
     def test_register_user(self):
         """Test user registration"""
         success, data = self.run_test(
@@ -361,6 +369,7 @@ class PersianMentalHealthAPITester:
 
         # Run tests in order
         self.test_health_check()
+        self.test_openapi_schema()
 
         # Registration and authentication flow
         if self.test_register_user():

--- a/k8s/microservices.yaml
+++ b/k8s/microservices.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: auth-service
+  template:
+    metadata:
+      labels:
+        app: auth-service
+    spec:
+      containers:
+      - name: auth-service
+        image: mental-ai-backend:latest
+        command: ["uvicorn", "services.auth_service:app", "--host", "0.0.0.0", "--port", "8001"]
+        ports:
+        - containerPort: 8001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-service
+spec:
+  selector:
+    app: auth-service
+  ports:
+  - port: 8001
+    targetPort: 8001
+    protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: assessments-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: assessments-service
+  template:
+    metadata:
+      labels:
+        app: assessments-service
+    spec:
+      containers:
+      - name: assessments-service
+        image: mental-ai-backend:latest
+        command: ["uvicorn", "services.assessments_service:app", "--host", "0.0.0.0", "--port", "8002"]
+        ports:
+        - containerPort: 8002
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: assessments-service
+spec:
+  selector:
+    app: assessments-service
+  ports:
+  - port: 8002
+    targetPort: 8002
+    protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trackers-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: trackers-service
+  template:
+    metadata:
+      labels:
+        app: trackers-service
+    spec:
+      containers:
+      - name: trackers-service
+        image: mental-ai-backend:latest
+        command: ["uvicorn", "services.trackers_service:app", "--host", "0.0.0.0", "--port", "8003"]
+        ports:
+        - containerPort: 8003
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: trackers-service
+spec:
+  selector:
+    app: trackers-service
+  ports:
+  - port: 8003
+    targetPort: 8003
+    protocol: TCP


### PR DESCRIPTION
## Summary
- add Kubernetes manifests to deploy auth, assessments, and trackers services
- document Kubernetes usage and Swagger URLs in README
- test OpenAPI schema availability

## Testing
- `python -m black backend backend_test.py`
- `python -m flake8 backend`
- `python -m mypy backend` *(fails: INTERNAL ERROR -- using transformers)*
- `npx eslint src --ext .js,.jsx` *(fails: Cannot find package '@eslint/js')*
- `pip install -r requirements.txt`
- `python backend_test.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fc33db5083289420c530516351b4