### PR TITLE
Add IDP microservice for JWT authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,12 @@ raise an error if this variable is missing.
 
 ### Backend
 
-Each API domain now runs as its own FastAPI service. Start the ones you need:
+Each API domain now runs as its own FastAPI service, including a dedicated IDP service for issuing JWTs. Start the ones you need:
 
 ```bash
 pip install -r requirements.txt
 cd backend
+uvicorn services.idp_service:app --reload --port 8000  # IDP service issuing JWTs
 uvicorn services.auth_service:app --reload --port 8001
 uvicorn services.assessments_service:app --reload --port 8002
 uvicorn services.trackers_service:app --reload --port 8003
@@ -135,6 +136,7 @@ Start the required FastAPI service in one terminal:
 
 ```bash
 cd backend
+uvicorn services.idp_service:app --reload --port 8000  # IDP service issuing JWTs
 uvicorn services.auth_service:app --reload --port 8001
 ```
 

--- a/backend/idp.py
+++ b/backend/idp.py
@@ -1,0 +1,57 @@
+import os
+from datetime import datetime, timedelta
+from typing import Dict, Optional
+
+import bcrypt
+import jwt
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import OAuth2PasswordRequestForm
+from pydantic import BaseModel
+
+SECRET_KEY = os.getenv("IDP_SECRET", "changeme")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60
+
+router = APIRouter()
+
+# In-memory user store for demonstration purposes
+fake_users_db: Dict[str, Dict[str, str]] = {
+    "alice": {
+        "username": "alice",
+        "hashed_password": bcrypt.hashpw(b"password", bcrypt.gensalt()).decode("utf-8"),
+    }
+}
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    return bcrypt.checkpw(password.encode("utf-8"), hashed.encode("utf-8"))
+
+
+def authenticate_user(username: str, password: str) -> Optional[Dict[str, str]]:
+    user = fake_users_db.get(username)
+    if not user:
+        return None
+    if not verify_password(password, user["hashed_password"]):
+        return None
+    return user
+
+
+def create_access_token(data: Dict[str, str]) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+@router.post("/token", response_model=Token)
+async def login(form_data: OAuth2PasswordRequestForm = Depends()) -> Token:
+    user = authenticate_user(form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+    token = create_access_token({"sub": user["username"]})
+    return Token(access_token=token, token_type="bearer")

--- a/backend/services/idp_service.py
+++ b/backend/services/idp_service.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+
+from idp import router as idp_router
+
+app = FastAPI(title="IDP Service")
+
+
+@app.get("/api/health")
+async def health_check():
+    return {"status": "healthy"}
+
+
+app.include_router(idp_router)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,11 @@
 version: '3.9'
 services:
+  idp-service:
+    build: .
+    working_dir: /backend
+    command: uvicorn services.idp_service:app --host 0.0.0.0 --port 8000
+    ports:
+      - "8000:8000"
   auth-service:
     build: .
     working_dir: /backend
@@ -43,6 +49,7 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:
+      - idp-service
       - auth-service
       - assessments-service
       - trackers-service


### PR DESCRIPTION
## Summary
- introduce standalone IDP service issuing JWTs for other microservices
- wire IDP service into docker-compose and project docs

## Testing
- `black backend`
- `flake8 backend`
- `mypy backend` *(fails: process hung in environment)*
- `python backend_test.py` *(fails: HTTPConnectionPool localhost connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fe90c6c083289125de8ce89db452